### PR TITLE
Use standard deviation to determine reliability of measurements in frequency window

### DIFF
--- a/app/src/main/java/ca/unb/mobiledev/tennis_tune/VisualizerView.kt
+++ b/app/src/main/java/ca/unb/mobiledev/tennis_tune/VisualizerView.kt
@@ -31,7 +31,7 @@ class VisualizerView(context: Context, attrs: AttributeSet? = null) : View(conte
     private var frequencyWindow = mutableListOf<Float>()
     private val frequencyWindowSize =
         60  // Use a rolling window of frequencies
-    private val frequencyWindowMaxStdDev = 5f
+    private val frequencyWindowMaxStdDev = 1f
 
     private var recentMagnitudesAverage = mutableListOf<Float>()
     private val maxMagnitudeAverageSize = fftSizeHalf  // For calculating background


### PR DESCRIPTION
#40 

This implements the following algorithm:

> The standard deviation of the frequencies within this window is calculated to determine the stability of the detected frequency. If the frequency detection is deemed stable, the mean frequency from the window is displayed.

Tested on emulator. 

Need to be tested on device.